### PR TITLE
No need to check if args.length is equal to 0

### DIFF
--- a/JavaScript/5-loop.js
+++ b/JavaScript/5-loop.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const compose = (...fns) => x => {
-  if (fns.length === 0) return x;
   const last = fns.length - 1;
   let res = x;
   for (let i = last; i >= 0; i--) {
@@ -11,7 +10,6 @@ const compose = (...fns) => x => {
 };
 
 const pipe = (...fns) => x => {
-  if (fns.length === 0) return x;
   let res = x;
   for (let i = 0; i < fns.length; i++) {
     res = fns[i](res);


### PR DESCRIPTION
We have already equated `x` to `res`. So, if `args` is empty, loop will be skipped and `x` will be returned by default as `res`.